### PR TITLE
Disable display of GitHub projects

### DIFF
--- a/gitprofile.config.ts
+++ b/gitprofile.config.ts
@@ -9,7 +9,7 @@ const CONFIG = {
   base: '/',
   projects: {
     github: {
-      display: true, // Display GitHub projects?
+      display: false, // Display GitHub projects?
       header: 'Github Projects',
       mode: 'automatic', // Mode can be: 'automatic' or 'manual'
       automatic: {


### PR DESCRIPTION
Changed display setting for GitHub projects to false. Personal git does not showcase my skills as well as work projects and history.